### PR TITLE
resolve race condition with report processing (thanks Bas van Sisseren)

### DIFF
--- a/core/scheduler.py
+++ b/core/scheduler.py
@@ -736,16 +736,17 @@ class AnalysisManager(threading.Thread):
             self.launch_analysis()
 
             if not self.is_vnc:
-                self.db.set_status(self.task.id, TASK_COMPLETED)
-
                 log.debug("Released database task #%d", self.task.id)
 
                 if self.cfg.cuckoo.process_results:
-                    # this updates self.task so processing gets the latest and greatest
                     self.store_task_info()
 
+                    self.db.set_status(self.task.id, TASK_COMPLETED)
+                    # TODO If self.process_results() is unified with apps.py's
+                    # process() method, then ensure that TASK_FAILED_PROCESSING is
+                    # handled correctly and not overwritten by the db.set_status()
+                    # at the end of this method.
                     self.process_results()
-                    self.db.set_status(self.task.id, TASK_REPORTED)
 
                 # We make a symbolic link ("latest") which links to the latest
                 # analysis - this is useful for debugging purposes. This is only
@@ -784,8 +785,14 @@ class AnalysisManager(threading.Thread):
                 "status": "error",
             })
 
-        task_log_stop(self.task.id)
-        active_analysis_count -= 1
+        finally:
+            if self.cfg.cuckoo.process_results:
+                self.db.set_status(self.task.id, TASK_REPORTED)
+            else:
+                self.db.set_status(self.task.id, TASK_COMPLETED)
+            task_log_stop(self.task.id)
+            active_analysis_count -= 1
+
 
 class Scheduler(object):
     """Tasks Scheduler.


### PR DESCRIPTION
When process_results was enabled the Scheduler would still log one
message after the task status had been set to TASK_REPORTED, potentially
logging to $CWD/storage/analyses/task_id/cuckoo.log while this file not
longer existed (as external processes may have already scooped the task).

When process_results was disabled the Scheduler would still log two
messages after setting TASK_COMPLETED, potentially writing to a closed
and removed file.

The above two situations would allow the final log.exception() in
AnalysisManager()'s run() method to throw an exception which, due to the
treading nature of this class, wasn't caught properly. Finally, the
exception would ignore the execution of task_log_stop() and decreasing
the active_analysis_count variable, which would hang Cuckoo forever in
the case of a "cuckoo -m 10000"-like situation.

This is now resolved thanks to Bas van Sisseren for identifying the root
cause and providing an initial patch to mitigate the issue.

Signed-off-by: Itay Hury <itay+github@huri.biz>